### PR TITLE
Fix syntax error in Unity plugin & add invoiceClosed support in JS plugin

### DIFF
--- a/Assets/PlayDeck/Runtime/PlayDeckBridge.cs
+++ b/Assets/PlayDeck/Runtime/PlayDeckBridge.cs
@@ -309,7 +309,7 @@ namespace PlayDeck
         
         private void GetPaymentInfoHandler(string getPaymentInfoJson)
         {
-            var settings = new JsonSerializerSettings {NullValueHandling = NullValueHandling Ignore};
+            var settings = new JsonSerializerSettings {NullValueHandling = NullValueHandling.Ignore};
             var converted = JsonConvert.DeserializeObject<GetPaymentInfoResponseData>(getPaymentInfoJson, settings);
             _getPaymentInfoResponseJson = converted;
             _getPaymentInfoRequestCallback?.Invoke(converted);

--- a/Assets/PlayDeck/Runtime/PlayDeckBridge.cs
+++ b/Assets/PlayDeck/Runtime/PlayDeckBridge.cs
@@ -75,6 +75,7 @@ namespace PlayDeck
         private Action<string> _getDataCallback;
         private Action<PaymentResponseData> _paymentRequestCallback;
         private Action<GetPaymentInfoResponseData> _getPaymentInfoRequestCallback;
+        private Action<string> _invoiceClosedCallback;
         private Action<string> _getShareLinkCallback;
         private Action<bool> _getPlaydeckStateCallback;
         
@@ -151,7 +152,18 @@ namespace PlayDeck
             PlayDeckBridge_PostMessage_RequestPayment(json);
 #endif
         }
-        
+
+        public void TrackInvoiceClosed(Action<string> callback)
+        {
+#if UNITY_EDITOR
+            Debug.Log($"[PlayDeckBridge]: Fake TrackInvoiceClosed");
+#else
+            _invoiceClosedCallback = callback;
+
+            Debug.Log($"[PlayDeckBridge]: TrackInvoiceClosed");
+#endif
+        }
+
         public void GetPaymentInfo(GetPaymentInfoRequestData requestData, Action<GetPaymentInfoResponseData> callback)
         {
 #if UNITY_EDITOR
@@ -314,7 +326,12 @@ namespace PlayDeck
             _getPaymentInfoResponseJson = converted;
             _getPaymentInfoRequestCallback?.Invoke(converted);
         }
-        
+
+        private void InvoiceClosedHandler(string status)
+        {
+            _invoiceClosedCallback?.Invoke(status);
+        }
+
         private void GetShareLinkHandler(string shareLink)
         {
             _getShareLinkCallback?.Invoke(shareLink);

--- a/Assets/Scripts/GameController.cs
+++ b/Assets/Scripts/GameController.cs
@@ -74,6 +74,8 @@ public class GameController : MonoBehaviour
         _setDataValueInput.onValueChanged.AddListener(val => _setDataValueValue = val);
         
         _openTelegramLink.onValueChanged.AddListener(val => _openTelegramLinkValue = val);
+
+        TrackInvoiceClosed();
     }
     
     public void GetData()
@@ -116,6 +118,16 @@ public class GameController : MonoBehaviour
             _messageViewer.Show($"Request payment response: " + JsonUtility.ToJson(responseData));
             
             _playDeckBridge.OpenTelegramLink(responseData.url);
+        });
+    }
+
+    public void TrackInvoiceClosed()
+    {
+        _playDeckBridge.TrackInvoiceClosed(status =>
+        {
+            Debug.Log("[Unity] Invoice closed status: " + status);
+
+            _messageViewer.Show($"Invoice closed status: " + status);
         });
     }
     

--- a/Assets/WebGLTemplates/CustomTemplate/playDeckBridge.js
+++ b/Assets/WebGLTemplates/CustomTemplate/playDeckBridge.js
@@ -26,6 +26,10 @@ var playDeckBridge = (function() {
             console.log(playdeck.value);
             _unityInstance?.SendMessage("PlayDeckBridge", "GetPaymentInfoHandler", JSON.stringify(playdeck.value))
         }
+        else if (playdeck.method === 'invoiceClosed') {
+            console.log(playdeck.value);
+            _unityInstance?.SendMessage("PlayDeckBridge", "InvoiceClosedHandler", JSON.stringify(playdeck.value));
+        }
         else if (playdeck.method === "getShareLink") {
             console.log(playdeck.value);
             _unityInstance?.SendMessage("PlayDeckBridge", "GetShareLinkHandler", playdeck.value);


### PR DESCRIPTION
* Fixed a syntax error in the `GetPaymentInfoHandler` method in the Unity plugin.
* Added support for the `invoiceClosed` method in the JS plugin.